### PR TITLE
Enable the use_srtp extension

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -54,6 +54,7 @@ impl Crypto {
         }
 
         let mut ssl_acceptor_builder = SslAcceptor::mozilla_intermediate(SslMethod::dtls())?;
+        ssl_acceptor_builder.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM").unwrap();
 
         // `webrtc-unreliable` does not bother to verify client certificates because it is designed
         // to be used as a dedicated server with arbitrary clients.  The client will verify the

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -54,7 +54,7 @@ impl Crypto {
         }
 
         let mut ssl_acceptor_builder = SslAcceptor::mozilla_intermediate(SslMethod::dtls())?;
-        ssl_acceptor_builder.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM").unwrap();
+        ssl_acceptor_builder.set_tlsext_use_srtp("SRTP_AEAD_AES_256_GCM:SRTP_AEAD_AES_128_GCM").unwrap();
 
         // `webrtc-unreliable` does not bother to verify client certificates because it is designed
         // to be used as a dedicated server with arbitrary clients.  The client will verify the


### PR DESCRIPTION
I was looking into the https://github.com/webrtc-rs/webrtc/issues/163 issue, and it turned out that it can be fixed if we enable the `use_srtp` for DTLS. I'm new to WebRTC and OpenSSL, so I don't know the full implications of this change, but it seems to fix the issue.

I pass all the protection profiles listed here:
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_tlsext_use_srtp.html

I don't know if there's a reason not to pass all of them when they are supported, I hope this works.