### PR TITLE
Accept SupportedExtensions param for unreliability

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -54,6 +54,7 @@ impl Crypto {
         }
 
         let mut ssl_acceptor_builder = SslAcceptor::mozilla_intermediate(SslMethod::dtls())?;
+        ssl_acceptor_builder.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM").unwrap();
 
         // `webrtc-unreliable` does not bother to verify client certificates because it is designed
         // to be used as a dedicated server with arbitrary clients.  The client will verify the

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -54,7 +54,6 @@ impl Crypto {
         }
 
         let mut ssl_acceptor_builder = SslAcceptor::mozilla_intermediate(SslMethod::dtls())?;
-        ssl_acceptor_builder.set_tlsext_use_srtp("SRTP_AEAD_AES_256_GCM:SRTP_AEAD_AES_128_GCM").unwrap();
 
         // `webrtc-unreliable` does not bother to verify client certificates because it is designed
         // to be used as a dedicated server with arbitrary clients.  The client will verify the

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -54,7 +54,7 @@ impl Crypto {
         }
 
         let mut ssl_acceptor_builder = SslAcceptor::mozilla_intermediate(SslMethod::dtls())?;
-        ssl_acceptor_builder.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM").unwrap();
+        ssl_acceptor_builder.set_tlsext_use_srtp("SRTP_AEAD_AES_256_GCM:SRTP_AEAD_AES_128_GCM").unwrap();
 
         // `webrtc-unreliable` does not bother to verify client certificates because it is designed
         // to be used as a dedicated server with arbitrary clients.  The client will verify the


### PR DESCRIPTION
This PR was branched from https://github.com/triplehex/webrtc-unreliable/pull/20

The changes in that PR to use SRTP, and the changes in this PR are necessary to support interop with https://github.com/webrtc-rs/webrtc

It appears that another way to indicate that ForwardTSN SCTP messages are available for use in a connection (which indicates complete unreliability is possible) is to pass the SupportedExtensions parameter through the InitAck chunk. (For more on this param: https://www.rfc-editor.org/rfc/rfc5061.html#page-13 )